### PR TITLE
Add basename to BrowserRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lostparagliders",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://Aloysb.github.io/lostparagliders_FE",
+  "homepage": "https://aloysb.github.io/lostparagliders_FE/",
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ const NoMatchPage = React.lazy(() => import('./scenes/NoMatch/NoMatchPage'));
 ReactDOM.render(
   <React.StrictMode>
     <GlobalStyle />
-    <Router>
+    <Router basename='/'>
       <Switch>
         <Suspense fallback={<div>Loading...</div>}>
           <Route exact path='/'>


### PR DESCRIPTION
Fix the issue with GH pages deploy of ReactRouter.